### PR TITLE
Introduce UVMap

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ fn main() -> std::io::Result<()> {
 
     let objects: Vec<RenderObject> = vec!{
     /* Plane */
-        RenderFloor::new (materials.get("floor").unwrap().clone(),       Vec3::new(  0.0, -300.0,  0.0),  Vec3::new(0., 1., 0.)),
+        RenderFloor::new (materials.get("floor").unwrap().clone(),       Vec3::new(  0.0, -500.0,  0.0),  Vec3::new(0., 1., 0.)),
         // RenderFloor::new (floor_material,       Vec3::new(-300.0,   0.0,  0.0),  Vec3::new(1., 0., 0.)),
     /* Spheres */
         RenderSphere::new(mirror_material.clone(), 80.0, Vec3::new(   0.0, -30.0,172.0)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod render;
 mod vec3;
 
 use render::{RenderColor,
+    UVMap,
     RenderMaterial, RenderPattern,
     RenderObject, RenderSphere, RenderFloor,
     RenderEnv, render};
@@ -147,7 +148,10 @@ fn main() -> std::io::Result<()> {
 
     let objects: Vec<RenderObject> = vec!{
     /* Plane */
-        RenderFloor::new (materials.get("floor").unwrap().clone(),       Vec3::new(  0.0, -500.0,  0.0),  Vec3::new(0., 1., 0.)),
+        RenderObject::Floor(
+            RenderFloor::new_raw(materials.get("floor").unwrap().clone(),       Vec3::new(  0.0, -300.0,  0.0),  Vec3::new(0., 1., 0.))
+            .uvmap(UVMap::ZX),
+        ),
         // RenderFloor::new (floor_material,       Vec3::new(-300.0,   0.0,  0.0),  Vec3::new(1., 0., 0.)),
     /* Spheres */
         RenderSphere::new(mirror_material.clone(), 80.0, Vec3::new(   0.0, -30.0,172.0)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,8 @@ fn main() -> std::io::Result<()> {
     let floor_material = Arc::new(RenderMaterial::new("floor".to_string(),
         RenderColor::new(1.0, 1.0, 0.0), RenderColor::new(0.0, 0.0, 0.0),  0, 0., 0.0)
         .pattern(RenderPattern::RepeatedGradation)
-        .pattern_scale(300.));
+        .pattern_scale(300.)
+        .pattern_angle_scale(0.2));
     materials.insert("floor".to_string(), floor_material.clone());
 
     let mirror_material = Arc::new(RenderMaterial::new("mirror".to_string(),


### PR DESCRIPTION
Implement customized methods to map UV coordinates from real coordinates.

Currently implemented mapping modes:

* XY
* YZ
* ZX
* LL - Longitude and Latitude mapping.

LL mode is best used for spheres.

![out](https://user-images.githubusercontent.com/2798715/70072952-58fbcd00-163b-11ea-9a8c-95630cf9be3c.png)
