### PR TITLE
Use clap crate to parse command line arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,14 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arc-swap"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +24,16 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -42,6 +60,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cfg-if"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "color_quant"
@@ -270,6 +302,14 @@ dependencies = [
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -643,6 +683,7 @@ dependencies = [
 name = "ray-rust"
 version = "0.1.0"
 dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -764,6 +805,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +827,14 @@ dependencies = [
  "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -860,6 +914,11 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +926,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -926,13 +990,16 @@ dependencies = [
 
 [metadata]
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
+"checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10004c15deb332055f7a4a208190aed362cf9a7c2f6ab70a305fba50e1105f38"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum color_quant 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0dbbb57365263e881e805dc77d94697c9118fd94d8da011240555aa7b23445bd"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2d818a4990769aac0c7ff1360e233ef3a41adcb009ebb2036bf6915eb0f6b23c"
@@ -959,6 +1026,7 @@ dependencies = [
 "checksum futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
 "checksum gif 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "86c2f2b597d6e05c86ee5947b2223bda468fe8dad3e88e2a6520869322aaf568"
 "checksum h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
+"checksum hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
 "checksum http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
 "checksum http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
@@ -1015,8 +1083,10 @@ dependencies = [
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
+"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum tiff 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b7c2cfc4742bd8a32f2e614339dd8ce30dbcf676bb262bd63a2327bc5df57d"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1bef565a52394086ecac0a6fa3b8ace4cb3a138ee1d96bd2b93283b56824e3"
@@ -1024,8 +1094,10 @@ dependencies = [
 "checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 "checksum tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
+"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ futures = { version = "0.3" }
 hyper = "0.13.1"
 tokio = { version = "0.2", features = ["full", "rt-threaded"] }
 tower-service = "0.3.0"
+
+clap = "2.20.3"

--- a/README.md
+++ b/README.md
@@ -10,10 +10,29 @@ A very simple Rust implementation of ray tracing renderer.
 
 ## Usage
 
-    ray-rust [width] [height] [-o output.png]
+    USAGE:
+        ray-rust.exe [FLAGS] [OPTIONS] <width> <height>
 
-Defaults:
+    FLAGS:
+        -h, --help         Prints help information
+        -m, --raymarch     Use ray marching
+        -V, --version      Prints version information
+        -w, --webserver    Launch a web server that responds with rendered image, rather than producing static images.
+                           Good for interactive session.
 
-    width: 640
-    height: 480
-    output: foo.png
+    OPTIONS:
+        -d, --deserialize_file <deserialize_file>
+                File name for deserialized scene input. If omitted, default scene is loaded.
+
+        -g, --gloweffect <gloweffect>
+                Enable glow effect and set its strength when ray marching method is used
+
+        -o, --output <output>                        Output file name [default: foo.png]
+        -p, --port_no <port_no>                      Port number, if use web server [default: 3000]
+        -s, --serialize_file <serialize_file>        File name for serialized scene output. If omitted, scene is not output.
+        -t, --threads <threads>                      thread count [default: 8]
+
+    ARGS:
+        <width>     Width of the image [px]
+        <height>    Height of the image [px]
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use render::{RenderColor,
     RenderEnv,
     render, render_frames};
 use vec3::Vec3;
-use webserver::{run_webserver, RenderParamStruct};
+use webserver::{run_webserver, ServerParams};
 use clap::{Arg, crate_version, crate_authors};
 
 fn main() -> std::io::Result<()> {
@@ -38,17 +38,12 @@ fn main() -> std::io::Result<()> {
         .version(crate_version!())
         .author(crate_authors!())
         .arg(Arg::with_name("width")
-            .help("Width of the image")
+            .help("Width of the image [px]")
             .required(true)
         )
         .arg(Arg::with_name("height")
-            .help("Height of the image")
+            .help("Height of the image [px]")
             .required(true)
-        )
-        .arg(Arg::with_name("flg")
-            .help("sample flag")
-            .short("f")
-            .long("flag")
         )
         .arg(Arg::with_name("threads")
             .help("thread count")
@@ -76,13 +71,13 @@ fn main() -> std::io::Result<()> {
             .takes_value(true)
         )
         .arg(Arg::with_name("serialize_file")
-            .help("serialize_file file name")
+            .help("File name for serialized scene output. If omitted, scene is not output.")
             .short("s")
             .long("serialize_file")
             .takes_value(true)
         )
         .arg(Arg::with_name("deserialize_file")
-            .help("deserialize_file file name")
+            .help("File name for deserialized scene input. If omitted, default scene is loaded.")
             .short("d")
             .long("deserialize_file")
             .takes_value(true)
@@ -91,6 +86,13 @@ fn main() -> std::io::Result<()> {
             .help("Use web server")
             .short("w")
             .long("webserver")
+        )
+        .arg(Arg::with_name("port_no")
+            .help("Port number, if use web server")
+            .short("p")
+            .long("port_no")
+            .takes_value(true)
+            .default_value("3000")
         )
         .get_matches();
 
@@ -129,6 +131,7 @@ fn main() -> std::io::Result<()> {
     let serialize_file = parser_opt::<String>(&matches, "serialize_file");
     let deserialize_file = parser_opt::<String>(&matches, "deserialize_file");
     let webserver = matches.is_present("webserver");
+    let port_no = parser(&matches, "port_no");
 
     let xmax: usize = width/*	((XRES + 1) * 2)*/;
     let ymax: usize = height/*	((YRES + 1) * 2)*/;
@@ -254,10 +257,11 @@ fn main() -> std::io::Result<()> {
     }
 
     if webserver {
-        return run_webserver(Arc::new(RenderParamStruct{
+        return run_webserver(Arc::new(ServerParams{
             width,
             height,
             thread_count,
+            port_no,
             ren
         }));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,14 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_yaml;
+extern crate clap;
 
-use std::env;
 use std::time::Instant;
 use std::io::prelude::*;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::str::FromStr;
+use std::fmt::{Display, Debug};
 use image::ColorType;
 
 mod render;
@@ -28,91 +30,105 @@ use render::{RenderColor,
     render, render_frames};
 use vec3::Vec3;
 use webserver::{run_webserver, RenderParamStruct};
-
+use clap::Arg;
 
 fn main() -> std::io::Result<()> {
 
-    if env::args().len() <= 1 {
-        println!("usage: {} [width] [height] [-o output] [-t thread_count] [-m] [-g glow_dist] [-s serialized.yaml] [-d serialized.yaml]", env::args().nth(0).unwrap());
-        return Ok(());
+    let matches = clap::App::new("ray-rust")
+        .version("0.1.0")
+        .author("myname <myname@mail.com>")
+        .arg(Arg::with_name("width")
+            .help("Width of the image")
+            .required(true)
+        )
+        .arg(Arg::with_name("height")
+            .help("Height of the image")
+            .required(true)
+        )
+        .arg(Arg::with_name("flg")
+            .help("sample flag")
+            .short("f")
+            .long("flag")
+        )
+        .arg(Arg::with_name("threads")
+            .help("thread count")
+            .short("t")
+            .long("threads")
+            .takes_value(true)
+            .default_value("8")
+        )
+        .arg(Arg::with_name("output")
+            .help("Output file name")
+            .short("o")
+            .long("output")
+            .takes_value(true)
+            .default_value("foo.png")
+        )
+        .arg(Arg::with_name("raymarch")
+            .help("Use ray marching")
+            .short("m")
+            .long("raymarch")
+        )
+        .arg(Arg::with_name("gloweffect")
+            .help("Use glow effect")
+            .short("g")
+            .long("gloweffect")
+            .takes_value(true)
+        )
+        .arg(Arg::with_name("serialize_file")
+            .help("serialize_file file name")
+            .short("s")
+            .long("serialize_file")
+            .takes_value(true)
+        )
+        .arg(Arg::with_name("deserialize_file")
+            .help("deserialize_file file name")
+            .short("d")
+            .long("deserialize_file")
+            .takes_value(true)
+        )
+        .arg(Arg::with_name("webserver")
+            .help("Use web server")
+            .short("w")
+            .long("webserver")
+        )
+        .get_matches();
+
+    fn parser<Output>(matches: &clap::ArgMatches, name: &str) -> Output
+        where Output: FromStr + Display,
+            <Output as FromStr>::Err : Debug
+    {
+        let ret = matches.value_of(name)
+            .expect(format!("{} must be specified", name).as_str())
+            .parse::<Output>()
+            .expect(format!("Parsing {} failed", name).as_str());
+        println!("Value for {}: {}", name, ret);
+        ret
     }
 
-    let (width, height, output, thread_count, use_raymarching, use_glow_effect, glow_effect, serialize_file, deserialize_file, webserver):
-        (usize, usize, String, i32, bool, bool, f32, String, String, bool) = {
-        let mut width = 640;
-        let mut width_set = false;
-        let mut height = 480;
-        let mut height_set = false;
-        let mut output = "foo.png".to_string();
-        let mut use_raymarching = false;
-        let mut use_glow_effect = false;
-        let mut glow_effect = 1.;
-        let mut thread_count = 8;
-        let mut serialize_file = "".to_string();
-        let mut deserialize_file = "".to_string();
-        let mut webserver = false;
-        #[derive(PartialEq)]
-        enum Next{Default, Output, ThreadCount, GlowEffect, SerializeFile, DeserializeFile}
-        let mut next = Next::Default;
-        for arg in env::args().skip(1) {
-            match next {
-                Next::Output => {
-                    output = arg.clone();
-                    next = Next::Default;
-                },
-                Next::ThreadCount => {
-                    thread_count = arg.parse().expect("thread count must be an int");
-                    assert!(1 <= thread_count);
-                    next = Next::Default;
-                },
-                Next::GlowEffect => {
-                    glow_effect = arg.parse().expect("thread count must be an int");
-                    next = Next::Default;
-                },
-                Next::SerializeFile => {
-                    serialize_file = arg;
-                    next = Next::Default;
-                }
-                Next::DeserializeFile => {
-                    deserialize_file = arg;
-                    next = Next::Default;
-                }
-                Next::Default => {
-                    if arg == "-o" {
-                        next = Next::Output;
-                    }
-                    else if arg == "-t" {
-                        next = Next::ThreadCount;
-                    }
-                    else if arg == "-m" {
-                        use_raymarching = true;
-                    }
-                    else if arg == "-g" {
-                        use_glow_effect = true;
-                        next = Next::GlowEffect;
-                    }
-                    else if arg == "-s" {
-                        next = Next::SerializeFile;
-                    }
-                    else if arg == "-d" {
-                        next = Next::DeserializeFile;
-                    }
-                    else if arg == "-w" {
-                        webserver = true;
-                    }
-                    else if !width_set {
-                        width = arg.parse().expect("width must be an int");
-                        width_set = true;
-                    }
-                    else if !height_set {
-                        height = arg.parse().expect("height must be an int");
-                        height_set = true;
-                    }
-                }
-            }
+    /// Parser procedure for optional parameter
+    fn parser_opt<Output>(matches: &clap::ArgMatches, name: &str) -> Option<Output>
+        where Output: FromStr + Display,
+            <Output as FromStr>::Err : Debug
+    {
+        let ret = matches.value_of(name)?
+            .parse::<Output>();
+        if let Ok(ref dbg) = ret {
+            println!("Value for {}: {}", name, dbg);
         }
-        (width, height, output, thread_count, use_raymarching, use_glow_effect, glow_effect, serialize_file, deserialize_file, webserver)
-    };
+        ret.ok()
+    }
+
+    let width = parser(&matches, "width");
+    let height = parser(&matches, "height");
+    let thread_count = parser(&matches, "threads");
+    let output: String = parser(&matches, "output");
+
+    let use_raymarching = matches.is_present("raymarch");
+    let glow_effect = parser_opt(&matches, "gloweffect");
+    let serialize_file = parser_opt::<String>(&matches, "serialize_file");
+    let deserialize_file = parser_opt::<String>(&matches, "deserialize_file");
+    let webserver = matches.is_present("webserver");
 
     let xmax: usize = width/*	((XRES + 1) * 2)*/;
     let ymax: usize = height/*	((YRES + 1) * 2)*/;
@@ -220,10 +236,10 @@ fn main() -> std::io::Result<()> {
         bgcolor, /* bgproc */
     ).light(Vec3::new(50., 60., -50.))
     .use_raymarching(use_raymarching)
-    .use_glow_effect(use_glow_effect, glow_effect);
+    .glow_effect(glow_effect);
 
-    if deserialize_file != "" {
-        let mut file = std::fs::File::open(deserialize_file)?;
+    if let Some(file_name) = deserialize_file {
+        let mut file = std::fs::File::open(file_name)?;
         let mut buf = String::new();
         file.read_to_string(&mut buf)?;
         ren.deserialize(&buf).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other,
@@ -246,8 +262,8 @@ fn main() -> std::io::Result<()> {
         }));
     }
 
-    if serialize_file != "" {
-        let mut file = std::fs::File::create(serialize_file)?;
+    if let Some(file_name) = serialize_file {
+        let mut file = std::fs::File::create(file_name)?;
         file.write_all(&ren.serialize()?.bytes().collect::<Vec<u8>>())?;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ use render::{RenderColor,
     render, render_frames};
 use vec3::Vec3;
 use webserver::{run_webserver, ServerParams};
-use clap::{Arg, crate_version, crate_authors};
+use clap::{Arg, crate_version, crate_authors, value_t};
 
 fn main() -> std::io::Result<()> {
 
@@ -65,7 +65,7 @@ fn main() -> std::io::Result<()> {
             .long("raymarch")
         )
         .arg(Arg::with_name("gloweffect")
-            .help("Use glow effect")
+            .help("Enable glow effect and set its strength when ray marching method is used")
             .short("g")
             .long("gloweffect")
             .takes_value(true)
@@ -83,7 +83,8 @@ fn main() -> std::io::Result<()> {
             .takes_value(true)
         )
         .arg(Arg::with_name("webserver")
-            .help("Use web server")
+            .help("Launch a web server that responds with rendered image, rather than producing static images.
+Good for interactive session.")
             .short("w")
             .long("webserver")
         )
@@ -100,9 +101,7 @@ fn main() -> std::io::Result<()> {
         where Output: FromStr + Display,
             <Output as FromStr>::Err : Debug
     {
-        let ret = matches.value_of(name)
-            .expect(format!("{} must be specified", name).as_str())
-            .parse::<Output>()
+        let ret = value_t!(matches, name, Output)
             .expect(format!("Parsing {} failed", name).as_str());
         println!("Value for {}: {}", name, ret);
         ret
@@ -113,8 +112,7 @@ fn main() -> std::io::Result<()> {
         where Output: FromStr + Display,
             <Output as FromStr>::Err : Debug
     {
-        let ret = matches.value_of(name)?
-            .parse::<Output>();
+        let ret = value_t!(matches, name, Output);
         if let Ok(ref dbg) = ret {
             println!("Value for {}: {}", name, dbg);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,13 +30,13 @@ use render::{RenderColor,
     render, render_frames};
 use vec3::Vec3;
 use webserver::{run_webserver, RenderParamStruct};
-use clap::Arg;
+use clap::{Arg, crate_version, crate_authors};
 
 fn main() -> std::io::Result<()> {
 
     let matches = clap::App::new("ray-rust")
-        .version("0.1.0")
-        .author("myname <myname@mail.com>")
+        .version(crate_version!())
+        .author(crate_authors!())
         .arg(Arg::with_name("width")
             .help("Width of the image")
             .required(true)

--- a/src/render.rs
+++ b/src/render.rs
@@ -608,8 +608,7 @@ pub struct RenderEnv{
     pub light: Vec3,
     pub bgproc: fn(ren: &RenderEnv, pos: &Vec3) -> RenderColor,
     pub use_raymarching: bool,
-    pub use_glow_effect: bool,
-    glow_effect: f32,
+    glow_effect: Option<f32>,
     pub max_reflections: i32,
     pub max_refractions: i32,
 }
@@ -653,8 +652,7 @@ impl RenderEnv{
             light: Vec3::new(0., 0., 1.),
             bgproc,
             use_raymarching: false,
-            use_glow_effect: false,
-            glow_effect: 1.,
+            glow_effect: None,
             max_reflections: MAX_REFLECTIONS,
             max_refractions: MAX_REFRACTIONS,
         }
@@ -670,8 +668,7 @@ impl RenderEnv{
         self
     }
 
-    pub fn use_glow_effect(mut self, f: bool, v: f32) -> Self{
-        self.use_glow_effect = f;
+    pub fn glow_effect(mut self, v: Option<f32>) -> Self{
         self.glow_effect = v;
         self
     }
@@ -1230,9 +1227,9 @@ fn raymarch(ren: &RenderEnv, vi: &mut Vec3, eye: &mut Vec3,
 	}
     // println!("raymarch loop end {:?}", eye);
 
-    (if ren.use_glow_effect {
+    (if let Some(glow_effect) = ren.glow_effect {
         let factor = if min_min_dist == std::f32::INFINITY { 1. }
-            else { 1. + (0. + ren.glow_effect * (0.99f32).powf(min_min_dist)) };
+            else { 1. + (0. + glow_effect * (0.99f32).powf(min_min_dist)) };
         RenderColor::new(
             factor * ret_color.r,
             factor * ret_color.g,

--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -24,8 +24,8 @@ pub struct ServerParams{
     pub ren: RenderEnv,
 }
 
-fn render_web(renparam: &ServerParams, ren: &RenderEnv) -> Vec<u8>{
-    let (width, height) = (renparam.width, renparam.height);
+fn render_web(params: &ServerParams, ren: &RenderEnv) -> Vec<u8>{
+    let (width, height) = (params.width, params.height);
     let mut data = vec![0u8; 3 * width * height];
     
     for y in 0..height {
@@ -42,13 +42,11 @@ fn render_web(renparam: &ServerParams, ren: &RenderEnv) -> Vec<u8>{
         data[(x as usize + y as usize * width) * 3 + 2] = (fc.b * 255.).min(255.) as u8;
     };
 
-    render(&ren, &mut putpoint, renparam.thread_count);
+    render(&ren, &mut putpoint, params.thread_count);
     data
 }
 
-async fn serve_req(req: Request<Body>, renparam: Arc<ServerParams>) -> Result<Response<Body>, hyper::Error> {
-    // Always return successfully with a response containing a body with
-    // a friendly greeting ;)
+async fn serve_req(req: Request<Body>, params: Arc<ServerParams>) -> Result<Response<Body>, hyper::Error> {
     println!("Got request at {:?} in thread #{:?}", req.uri(), thread::current().id());
 
     use std::f32::consts::PI;
@@ -68,11 +66,11 @@ async fn serve_req(req: Request<Body>, renparam: Arc<ServerParams>) -> Result<Re
                 var z = {};
                 var yaw = {};
                 var pitch = {};\n",
-                renparam.ren.camera.position.x,
-                renparam.ren.camera.position.y,
-                renparam.ren.camera.position.z,
-                renparam.ren.camera.pyr.y * 180. / PI,
-                renparam.ren.camera.pyr.x * 180. / PI)
+                params.ren.camera.position.x,
+                params.ren.camera.position.y,
+                params.ren.camera.position.z,
+                params.ren.camera.pyr.y * 180. / PI,
+                params.ren.camera.pyr.x * 180. / PI)
                 + "
                 var buttonStates = {
                     w: false,
@@ -250,7 +248,7 @@ async fn serve_req(req: Request<Body>, renparam: Arc<ServerParams>) -> Result<Re
 
         // Cloning a whole RenderEnv object is dumb, but probably faster than deserializing from
         // a file in every request, and we need to modify camera position.
-        let mut ren = renparam.ren.clone();
+        let mut ren = params.ren.clone();
         ren.camera.position.x = xpos;
         ren.camera.position.y = ypos;
         ren.camera.position.z = zpos;
@@ -258,7 +256,7 @@ async fn serve_req(req: Request<Body>, renparam: Arc<ServerParams>) -> Result<Re
         ren.camera.pyr.x = pitch * PI / 180.;
         ren.camera.rotation = Quat::from_pyr(&ren.camera.pyr);
         let imbuf = image::DynamicImage::ImageRgb8(image::ImageBuffer::from_raw(
-            renparam.width as u32, renparam.height as u32, render_web(&renparam, &ren)).unwrap());
+            params.width as u32, params.height as u32, render_web(&params, &ren)).unwrap());
         let mut buf: Vec<u8> = vec![];
         if let Ok(_) = imbuf.write_to(&mut buf, image::ImageOutputFormat::PNG) {
             // let enc = image::png::PNGEncoder::new();
@@ -287,15 +285,6 @@ async fn run_server(addr: SocketAddr, params: Arc<ServerParams>) {
 
     // Create a server bound on the provided address
     let serve_future = Server::bind(&addr)
-        // Serve requests using our `async serve_req` function.
-        // `serve` takes a closure which returns a type implementing the
-        // `Service` trait. `service_fn` returns a value implementing the
-        // `Service` trait, and accepts a closure which goes from request
-        // to a future of the response. To use our `serve_req` function with
-        // Hyper, we have to box it and put it in a compatability
-        // wrapper to go from a futures 0.3 future (the kind returned by
-        // `async fn`) to a futures 0.1 future (the kind used by Hyper).
-        // .serve(|| service_fn(|req| serve_req(req, params.clone()).boxed().compat()));
         .serve(make_payload_service(|_, params| async move {
             Ok::<_, Error>(payload_service(|req, params| serve_req(req, params), params))
         }, params));
@@ -307,27 +296,13 @@ async fn run_server(addr: SocketAddr, params: Arc<ServerParams>) {
     }
 }
 
-pub fn run_webserver(ren: Arc<ServerParams>) -> std::io::Result<()>{
-    // Set the address to run our socket on.
-    let addr = SocketAddr::from(([0, 0, 0, 0], ren.as_ref().port_no));
+pub fn run_webserver(params: Arc<ServerParams>) -> std::io::Result<()>{
+    let addr = SocketAddr::from(([0, 0, 0, 0], params.as_ref().port_no));
 
-    // Call our `run_server` function, which returns a future.
-    // As with every `async fn`, for `run_server` to do anything,
-    // the returned future needs to be run. Additionally,
-    // we need to convert the returned future from a futures 0.3 future into a
-    // futures 0.1 future.
-    let futures_03_future = run_server(addr, ren);
-        // |req: Request<Body>| async {
-        //     // let ren_clone = ren.clone();
-        //     serve_req(req/*, ren_clone*/).await
-        // });
-    // let futures_01_future = futures_03_future.unit_error().boxed().compat();
+    let future = run_server(addr, params);
 
-    // Finally, we can run the future to completion using the `run` function
-    // provided by Hyper.
-    // run(futures_01_future);
     let mut rt = Runtime::new()?;
-    rt.block_on(futures_03_future);
+    rt.block_on(future);
 
     Ok(())
 }


### PR DESCRIPTION
Currently we're using own-implemented argument parser, but it's not very reliable nor scalable.

There is a very convenient crate to automate parsing the arguments called clap.